### PR TITLE
Relax version bounds and some other stuff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.0.2
+
+- Relax version bounds to support `Diff-0.4`
+
 # 0.2.0.1
 
 - Relax version bounds to support `tasty-1.3.x` and `Diff-0.4`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.0.1
+
+- Relax version bounds to support `tasty-1.3.x` and `Diff-0.4`
+
 # 0.1.0.0
 
 - Initial implementation.

--- a/default.nix
+++ b/default.nix
@@ -1,3 +1,3 @@
-{ pkgs ? import ./nixpkgs.nix }:
+let pkgs = import ./nixpkgs.nix;
 
-pkgs.haskellPackages.callCabal2nix "pretty-diff" ./. { }
+in pkgs.haskellPackages.callCabal2nix "pretty-diff" ./. { }

--- a/junit-xml.nix
+++ b/junit-xml.nix
@@ -13,7 +13,7 @@ self: super:
         url = "git@github.com:jwoudenberg/junit-xml";
         rev = "9b5745c3c190205f662233abe5e3bf65e12fd55c";
       };
-    in self.haskell.lib.dontCheck
-    (self.haskellPackages.callCabal2nix "junit-xml" src { });
+      in self.haskell.lib.dontCheck
+      (self.haskellPackages.callCabal2nix "junit-xml" src { });
   });
 }

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -3,12 +3,12 @@ let
   #
   # Pick a release (e.g. nixpkgs-unstable) and open the `git-revision`
   # file. It will contain a revision hash. Copy and paste it below.
-  rev = "a8fc904c7c0d66f07d22bcb59a46d2bd72f8ddae";
+  rev = "0c59c1296b23abc25a6383ff26db2eeb17ad8a81";
   # Generate the SHA256 hash for this revision's tarball.
   #
   #   $ nix-prefetch-url --unpack --type sha256 \
   #   >   https://github.com/NixOS/nixpkgs/archive/${rev-defined-above}.tar.gz
-  sha256 = "142gzi01601c95hrwjizjc25qsmswldzw2zg6fvgw52lpag2w2qb";
+  sha256 = "03sifcpkc3prszaycd6snvpxam66phmj0b7m4723l5dmmsyq4bkw";
   nixpkgs = builtins.fetchTarball {
     url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
     sha256 = sha256;

--- a/package.yaml
+++ b/package.yaml
@@ -16,7 +16,7 @@ library:
   dependencies:
   - base >= 4.10.1.0 && < 5
   - data-default >= 0.7 && < 0.8
-  - Diff >= 0.3 && < 0.4
+  - Diff >= 0.3 && < 0.5
   - text >= 1.2 && < 1.3
   exposed-modules:
   - Pretty.Diff
@@ -25,13 +25,13 @@ tests:
   spec:
     dependencies:
     - base
-    - Diff >= 0.3 && < 0.5
-    - data-default >= 0.7 && < 0.8
+    - Diff
+    - data-default
     - tasty >= 1.1 && < 1.4
     - tasty-hunit
     - pretty-diff
     - tasty-test-reporter
-    - text >= 1.2 && < 1.3
+    - text
     main: Main.hs
     source-dirs:
     - test

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: pretty-diff
-version: 0.2.0.1
+version: 0.2.0.2
 synopsis: Pretty printing a diff of two values.
 description: Please see the README at <https://github.com/stoeffel/pretty-diff>.
 author: Christoph Hermann

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: pretty-diff
-version: 0.2.0.0
+version: 0.2.0.1
 synopsis: Pretty printing a diff of two values.
 description: Please see the README at <https://github.com/stoeffel/pretty-diff>.
 author: Christoph Hermann
@@ -25,9 +25,9 @@ tests:
   spec:
     dependencies:
     - base
-    - Diff >= 0.3 && < 0.4
+    - Diff >= 0.3 && < 0.5
     - data-default >= 0.7 && < 0.8
-    - tasty >= 1.1 && < 1.3
+    - tasty >= 1.1 && < 1.4
     - tasty-hunit
     - pretty-diff
     - tasty-test-reporter

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+name=$(grep name: < package.yaml | awk '{print $2}')
+version=$(grep version: < package.yaml | awk '{print $2}')
+bundle="$name-$version.tar.gz"
+
+# check changelog contains an entry for this version
+grep "^# $version$" < CHANGELOG.md
+
+hpack
+cabal sdist -o - > "$bundle"
+cabal upload --publish "$bundle"
+cabal upload -d --publish

--- a/shell.nix
+++ b/shell.nix
@@ -1,19 +1,11 @@
-{ pkgs ? import ./nixpkgs.nix }:
-
-let
-  ormolu = pkgs.haskellPackages.callCabal2nix "ormolu" (pkgs.fetchFromGitHub {
-    owner = "tweag";
-    repo = "ormolu";
-    rev = "3abadaefa5e190ff346f9aeb309465ac890495c2";
-    sha256 = "0vqrb12bsp1dczff3i5pajzhjwz035rxg8vznrgj5p6j7mb2vcnd";
-  }) { };
+let pkgs = import ./nixpkgs.nix;
 
 in pkgs.haskellPackages.shellFor {
-  packages = p: [ (pkgs.callPackage ./default.nix { }) ];
+  packages = p: [ (import ./default.nix) ];
   buildInputs = [
     pkgs.cabal-install
     pkgs.haskellPackages.ghcid
     pkgs.haskellPackages.hpack
-    ormolu
+    pkgs.ormolu
   ];
 }


### PR DESCRIPTION
- Relax version bounds of `tasty` and `Diff` to encompass their latest versions. That way we'll be able to publish to stackage.
- Add a `release.sh` script.
- Update some Nix stuff (newer version of `nixpkgs`, get Ormolu directly from `nixpkgs`)

Already released this here: https://hackage.haskell.org/package/pretty-diff-0.2.0.1